### PR TITLE
[INFR-2594] Modify docker build and docker run commands to run using local user and Group ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ S3_BUCKET = $(APP_NAME)-$(AWS_PROFILE)-$(USERNAME)
 
 ifneq ($(USE_DOCKER),no)
 	PROJECT_DIR ?=  $(shell pwd)
-	DOCKER = docker run -t -v ${PROJECT_DIR}:/app $(APP_NAME):latest
+	DOCKER = docker run --user ${UID}:${GID} -t -v ${PROJECT_DIR}:/app $(APP_NAME):latest
 endif
 
 .SILENT:
@@ -36,7 +36,7 @@ setup:
 
 ## Build the docker image to execute make commands locally
 docker-build:	
-	docker build -f build/ci/Dockerfile . -t $(APP_NAME):latest
+	docker build --build-arg UID=${UID} --build-arg GID=${GID} -f build/ci/Dockerfile . -t $(APP_NAME):latest
 
 ## install npm dependencies
 install:

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -4,4 +4,10 @@ COPY build/ci/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
+ARG UID
+ARG GID
+
+RUN mkdir /.npm && \
+chown $UID:$GID -R /.npm
+
 WORKDIR /app


### PR DESCRIPTION
[INFR-2594]

## Overview
Fix issues with docker containers and permissions when mounting local filesystem to docker to build and run the projects.

## Problem
.aws-sam/ directory becomes owned by root user and causes write issues with Jenkins pipeline runs. This fix will ensure that docker will run with the current User and Group ID.

## Change log
- Update npm cache directory permissions on Docker container to be owned by local host User and Group IDs.
- Include build args for UID and GID in Dockerfile
- Modified docker run to use host system UID/GID.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). This requires a major version bump.
- [ ] This change requires a documentation update.

## How can this be tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


[INFR-2594]: https://zavamed.atlassian.net/browse/INFR-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ