### PR TITLE
changed npm install to npm ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ docker-build:
 
 ## install npm dependencies
 install:
-	${DOCKER} npm install
+	${DOCKER} npm ci
 
 ## Run linter
 lint:


### PR DESCRIPTION
## Overview

npm ci uses the packages.lock.json file to resolve versions of dependencies which are specific versions 

npm install uses the packages.json file rules which can lead to different versions of dependencies being installed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
